### PR TITLE
fixes to ci-cd

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # GitHub Actions dependencies
+  # GitHub Actions dependencies only
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,18 +12,4 @@ updates:
       - "chizy7"
     commit-message:
       prefix: "ci"
-      include: "scope"
-
-  # NPM dependencies (if I add any Node.js tooling)
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "chizy7"
-    assignees:
-      - "chizy7"
-    commit-message:
-      prefix: "deps"
       include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev
+        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev libwebsocketpp-dev
 
     - name: Build Release
       run: |


### PR DESCRIPTION
Fixes to ensure CI/CD passes on merge


## Reminder to self
Fix thread and lock free issues for disabled tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited automated dependency updates to GitHub Actions only.
  * Updated CI security scan to use explicit minimal permissions for improved security posture.
  * Added installation of libwebsocketpp-dev in the release workflow to ensure reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->