### PR TITLE
Fix docker release issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository }}
+        images: ghcr.io/${{ github.repository_owner }}/pinnaclemm
         tags: |
           type=ref,event=branch
           type=semver,pattern={{version}}
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test Docker image
       run: |
-        docker run --rm ghcr.io/${{ github.repository }}:latest --help
+        docker run --rm ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest --help
 
     - name: Package Release Assets
       run: |
@@ -127,27 +127,27 @@ jobs:
 
         ## Pull the image
         ```bash
-        docker pull ghcr.io/${{ github.repository }}:latest
+        docker pull ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest
         ```
 
         ## Run in simulation mode
         ```bash
-        docker run --rm ghcr.io/${{ github.repository }}:latest
+        docker run --rm ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest
         ```
 
         ## Run with custom parameters
         ```bash
-        docker run --rm ghcr.io/${{ github.repository }}:latest --mode simulation --symbol ETH-USD --verbose
+        docker run --rm ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest --mode simulation --symbol ETH-USD --verbose
         ```
 
         ## Setup credentials (for live trading)
         ```bash
-        docker run -it --rm -v $(pwd)/config:/app/config ghcr.io/${{ github.repository }}:latest --setup-credentials
+        docker run -it --rm -v $(pwd)/config:/app/config ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest --setup-credentials
         ```
 
         ## Run in live mode
         ```bash
-        docker run -it --rm -v $(pwd)/config:/app/config ghcr.io/${{ github.repository }}:latest --mode live --exchange coinbase --symbol BTC-USD --verbose
+        docker run -it --rm -v $(pwd)/config:/app/config ghcr.io/${{ github.repository_owner }}/pinnaclemm:latest --mode live --exchange coinbase --symbol BTC-USD --verbose
         ```
         EOF
 


### PR DESCRIPTION
Minor fix to resolve issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker usage examples in release assets to reference ghcr.io/${{ github.repository_owner }}/pinnaclemm for pull, run, and mode-specific commands.
  * Clarified example commands to consistently use the owner-scoped image path.

* **Chores**
  * Standardized all release workflow image references to ghcr.io/${{ github.repository_owner }}/pinnaclemm (including tests and generated assets).
  * No changes to release logic or build steps; only image path renaming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->