### PR TITLE
Added latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           type=sha
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
fixes to release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Docker images built from the default branch now also publish a latest tag, alongside existing tags (branch refs, semver, commit SHA).
  * You can pull the most recent default-branch image using the latest tag; behavior for other branches and tags is unchanged.
  * This update affects image tagging only; no changes to application features, release steps, or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->