### PR TITLE
chore: gitignore backtest_results output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ data/*.csv
 data/*.json
 *.log
 
+# Backtest output
+backtest_results/
+
 # Dependency directories
 third_party/
 


### PR DESCRIPTION
Engine's --backtest-output writes here; shouldn't be committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude `backtest_results/` directory from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->