### PR TITLE
fix(build): pin fmt/spdlog and remove unused websocketpp dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev libwebsocketpp-dev
+        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev
 
     - name: Setup dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install cmake boost openssl nlohmann-json googletest google-benchmark websocketpp
+        brew install cmake boost openssl nlohmann-json googletest google-benchmark
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev libwebsocketpp-dev
+        sudo apt-get install -y cmake build-essential libboost-all-dev libssl-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev
 
     - name: Build Release
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,24 +79,29 @@ find_package(nlohmann_json REQUIRED)
 # Handle spdlog and fmt with fallback to FetchContent
 include(FetchContent)
 
-find_package(spdlog QUIET)
-if(NOT spdlog_FOUND)
-  message(STATUS "spdlog not found, downloading...")
-  FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.12.0)
-  FetchContent_MakeAvailable(spdlog)
-endif()
-
-find_package(fmt QUIET)
+# fmt must be resolved before spdlog so a fetched spdlog can build against it
+# (SPDLOG_FMT_EXTERNAL) instead of its bundled fmt copy
+find_package(fmt 11.2.0 QUIET)
 if(NOT fmt_FOUND)
   message(STATUS "fmt not found, downloading...")
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 10.1.1)
+    GIT_TAG 11.2.0)
   FetchContent_MakeAvailable(fmt)
+endif()
+
+find_package(spdlog 1.15.3 QUIET)
+if(NOT spdlog_FOUND)
+  message(STATUS "spdlog not found, downloading...")
+  set(SPDLOG_FMT_EXTERNAL
+      ON
+      CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+    spdlog
+    GIT_REPOSITORY https://github.com/gabime/spdlog.git
+    GIT_TAG v1.15.3)
+  FetchContent_MakeAvailable(spdlog)
 endif()
 
 # Create OpenSSL targets if they don't exist (for compatibility with older
@@ -115,23 +120,6 @@ if(OPENSSL_FOUND AND NOT TARGET OpenSSL::Crypto)
     OpenSSL::Crypto
     PROPERTIES IMPORTED_LOCATION "${OPENSSL_CRYPTO_LIBRARY}"
                INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}")
-endif()
-
-# WebSocket++ is a header-only library
-find_path(WEBSOCKETPP_INCLUDE_DIRS websocketpp/client.hpp
-          HINTS /usr/local/include /usr/include /opt/homebrew/include)
-if(NOT WEBSOCKETPP_INCLUDE_DIRS)
-  message(STATUS "WebSocket++ not found in system, downloading...")
-  # Set policy to handle older CMake versions in WebSocket++
-  set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
-  FetchContent_Declare(
-    websocketpp
-    GIT_REPOSITORY https://github.com/zaphoyd/websocketpp.git
-    GIT_TAG 0.8.2
-    GIT_SHALLOW TRUE
-    CONFIGURE_COMMAND "" BUILD_COMMAND "")
-  FetchContent_MakeAvailable(websocketpp)
-  set(WEBSOCKETPP_INCLUDE_DIRS ${websocketpp_SOURCE_DIR})
 endif()
 
 # hffix is a header-only FIX protocol library
@@ -164,8 +152,7 @@ if(ENABLE_LTO)
 endif()
 
 # Include directories
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${WEBSOCKETPP_INCLUDE_DIRS}
-                    ${HFFIX_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${HFFIX_INCLUDE_DIRS})
 
 # Add TBB if enabled
 if(USE_TBB)
@@ -316,9 +303,7 @@ if(BUILD_VISUALIZATION)
            spdlog::spdlog
            fmt::fmt)
 
-  target_include_directories(visualization PRIVATE ${WEBSOCKETPP_INCLUDE_DIRS})
-  target_compile_definitions(visualization PRIVATE ASIO_STANDALONE
-                                                   BUILD_VISUALIZATION)
+  target_compile_definitions(visualization PRIVATE BUILD_VISUALIZATION)
 endif()
 
 # Main executable

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcrypto++8 \
     openssl \
     nlohmann-json3-dev \
-    libwebsocketpp-dev \
     pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && ldconfig

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Read more about the [system architecture](docs/architecture/system_overview.md).
 - C++20 compatible compiler (GCC 10+, Clang 10+, or MSVC 2019+)
 - CMake 3.14+
 - Boost libraries 1.72+
-- spdlog library (for structured logging)
-- fmt library (for formatting, spdlog dependency)
+- spdlog library (for structured logging; auto-downloaded at v1.15.3 if not installed)
+- fmt library (for formatting, spdlog dependency; auto-downloaded at 11.2.0 if not installed)
 - OpenSSL library (for secure credential handling)
 - nlohmann_json library (for configuration handling)
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -9,8 +9,8 @@ To build and run PinnacleMM, you'll need the following:
 - **C++20 compatible compiler** (GCC 10+, Clang 10+, or MSVC 2019+)
 - **CMake** (version 3.14 or higher)
 - **Boost libraries** (version 1.72 or higher)
-- **spdlog** (for structured logging)
-- **fmt** (formatting library, required by spdlog)
+- **spdlog** (for structured logging; auto-downloaded at v1.15.3 via FetchContent if not installed)
+- **fmt** (formatting library, required by spdlog; auto-downloaded at 11.2.0 via FetchContent if not installed)
 - **Google Test** (for running unit tests)
 - **Git** (for cloning the repository)
 


### PR DESCRIPTION
## Summary
- Bump FetchContent pins to fmt 11.2.0 and spdlog v1.15.3, with spdlog built against the external fmt (`SPDLOG_FMT_EXTERNAL`) instead of its bundled copy; fixes the `consteval` compile errors on the macOS CI runners (fixes #66)
- Remove the unused websocketpp dependency from CMake, CI workflows, and Dockerfile, all WebSocket code uses Boost.Beast; the leftover FetchContent fallback broke configure on CMake >= 4 (fixes #68)
- Document the pinned fallback versions in README and getting started guide

## Verification
- Reproduced the CI failure path locally (Debug + ASan, FetchContent-forced, Apple Clang 21): configure and full build now pass with zero consteval errors
- Fresh configure succeeds on CMake >= 4 without websocketpp installed and without any policy workaround
- Full default build with system deps: 0 errors; all six CI unit test executables pass in both configurations