### PR TITLE
ci: pin hadolint image and skip docker login on fork PRs

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -22,7 +22,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
+    # Authenticated pulls avoid Docker Hub rate limits, but fork PRs don't
+    # receive repository secrets, so skip the login there instead of failing.
     - name: Log in to Docker Hub
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,10 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
+        # The upstream hook runs the untagged image (:latest), so new hadolint
+        # releases can change lint results overnight. Pin the image to the same
+        # version as `rev` and bump both together deliberately.
+        entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint
         args: ['--ignore', 'DL3008', '--ignore', 'DL3009']
 
   # Shell script linting


### PR DESCRIPTION
Pins the hadolint pre-commit hook to its v2.12.0 image (the upstream hook runs :latest, which drifted and broke lint on every open PR) and skips the Docker Hub login on fork PRs, where repository secrets are never available.