### PR TITLE
feat: apply REST performance time range filters

### DIFF
--- a/tests/unit/WebServerTests.cpp
+++ b/tests/unit/WebServerTests.cpp
@@ -4,6 +4,49 @@
 
 namespace pinnacle::visualization {
 
+class PerformanceHistory : public ::testing::Test {
+protected:
+  PerformanceCollector collector;
+};
+
+TEST_F(PerformanceHistory, FiltersSnapshotsInclusivelyByTimeRange) {
+  PerformanceData first;
+  first.timestamp = 100;
+  first.pnl = 1.0;
+  PerformanceData second;
+  second.timestamp = 200;
+  second.pnl = 2.0;
+  PerformanceData third;
+  third.timestamp = 300;
+  third.pnl = 3.0;
+
+  collector.recordPerformance("strategy", first);
+  collector.recordPerformance("strategy", second);
+  collector.recordPerformance("strategy", third);
+
+  auto history = collector.getPerformanceHistory("strategy", 200, 300);
+
+  ASSERT_EQ(history.size(), 2);
+  EXPECT_EQ(history[0].timestamp, 200);
+  EXPECT_EQ(history[1].timestamp, 300);
+}
+
+TEST_F(PerformanceHistory, AppliesMaximumHistorySize) {
+  collector.setMaxHistorySize(2);
+
+  for (uint64_t timestamp = 1; timestamp <= 3; ++timestamp) {
+    PerformanceData data;
+    data.timestamp = timestamp;
+    collector.recordPerformance("strategy", data);
+  }
+
+  auto history = collector.getPerformanceHistory("strategy", 0, 3);
+
+  ASSERT_EQ(history.size(), 2);
+  EXPECT_EQ(history[0].timestamp, 2);
+  EXPECT_EQ(history[1].timestamp, 3);
+}
+
 TEST(QueryString, ParsesStandardQueryParameters) {
   auto params = parseQueryString("start=1234567890&end=9876543210&limit=100");
 

--- a/visualization/WebServer.cpp
+++ b/visualization/WebServer.cpp
@@ -1097,6 +1097,11 @@ parseQueryString(const std::string& query) {
   return params;
 }
 
+std::string RestAPIServer::urlDecode(const std::string& str) {
+  std::string decoded;
+  return decodeQueryComponent(str, decoded) ? decoded : std::string{};
+}
+
 std::string RestAPIServer::extractPath(const std::string& target) {
   auto pos = target.find('?');
   return pos != std::string::npos ? target.substr(0, pos) : target;

--- a/visualization/WebServer.cpp
+++ b/visualization/WebServer.cpp
@@ -6,8 +6,10 @@
 #include "../strategies/analytics/MarketRegimeDetector.h"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <fstream>
+#include <limits>
 #include <spdlog/spdlog.h>
 #include <sstream>
 
@@ -82,6 +84,19 @@ void PerformanceCollector::registerStrategy(const std::string& strategyId,
 void PerformanceCollector::unregisterStrategy(const std::string& strategyId) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_performanceData.erase(strategyId);
+  m_performanceHistory.erase(strategyId);
+}
+
+void PerformanceCollector::recordPerformance(const std::string& strategyId,
+                                             const PerformanceData& data) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_performanceData[strategyId] = data;
+
+  auto& history = m_performanceHistory[strategyId];
+  history.push_back(data);
+  while (history.size() > m_maxHistorySize) {
+    history.pop_front();
+  }
 }
 
 void PerformanceCollector::startCollection(uint64_t intervalMs) {
@@ -114,6 +129,25 @@ PerformanceData PerformanceCollector::getLatestPerformance(
   return PerformanceData{};
 }
 
+std::vector<PerformanceData> PerformanceCollector::getPerformanceHistory(
+    const std::string& strategyId, uint64_t startTime, uint64_t endTime) const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<PerformanceData> result;
+
+  auto it = m_performanceHistory.find(strategyId);
+  if (it == m_performanceHistory.end()) {
+    return result;
+  }
+
+  for (const auto& data : it->second) {
+    if (data.timestamp >= startTime && data.timestamp <= endTime) {
+      result.push_back(data);
+    }
+  }
+
+  return result;
+}
+
 std::vector<ChartDataPoint>
 PerformanceCollector::getChartData(const std::string& strategyId,
                                    const std::string& metric,
@@ -131,6 +165,13 @@ size_t PerformanceCollector::getRegisteredStrategiesCount() const {
 void PerformanceCollector::setMaxHistorySize(size_t maxSize) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_maxHistorySize = maxSize;
+
+  for (auto& [strategyId, history] : m_performanceHistory) {
+    boost::ignore_unused(strategyId);
+    while (history.size() > m_maxHistorySize) {
+      history.pop_front();
+    }
+  }
 }
 
 void PerformanceCollector::updateMarketData(const std::string& symbol,
@@ -968,17 +1009,62 @@ http::response<http::string_body> RestAPIServer::handleGetStrategies() {
 http::response<http::string_body>
 RestAPIServer::handleGetPerformance(const std::string& strategyId,
                                     const std::string& query) {
-  boost::ignore_unused(query);
+  auto params = parseQueryString(query);
+  const auto hasStart = params.contains("start");
+  const auto hasEnd = params.contains("end");
 
-  auto data = m_collector->getLatestPerformance(strategyId);
-  json performance = {{"pnl", data.pnl},
-                      {"position", data.position},
-                      {"sharpe_ratio", data.sharpeRatio},
-                      {"max_drawdown", data.maxDrawdown},
-                      {"win_rate", data.winRate},
-                      {"total_trades", data.totalTrades},
-                      {"ml_accuracy", data.mlAccuracy},
-                      {"prediction_time", data.avgPredictionTime}};
+  auto parseTimestamp = [](const std::string& value, uint64_t& timestamp) {
+    if (value.empty()) {
+      return false;
+    }
+
+    auto result =
+        std::from_chars(value.data(), value.data() + value.size(), timestamp);
+    return result.ec == std::errc{} &&
+           result.ptr == value.data() + value.size();
+  };
+
+  json performance;
+  if (hasStart || hasEnd) {
+    uint64_t startTime = 0;
+    uint64_t endTime = std::numeric_limits<uint64_t>::max();
+    if ((hasStart && !parseTimestamp(params.at("start"), startTime)) ||
+        (hasEnd && !parseTimestamp(params.at("end"), endTime)) ||
+        startTime > endTime) {
+      http::response<http::string_body> res{http::status::bad_request, 11};
+      res.set(http::field::server, "PinnacleMM-Visualization/1.0");
+      res.set(http::field::content_type, "application/json");
+      res.body() =
+          createErrorResponse("Invalid performance time range", 400).dump();
+      res.prepare_payload();
+      return res;
+    }
+
+    json history = json::array();
+    for (const auto& data :
+         m_collector->getPerformanceHistory(strategyId, startTime, endTime)) {
+      history.push_back({{"timestamp", data.timestamp},
+                         {"pnl", data.pnl},
+                         {"position", data.position},
+                         {"sharpe_ratio", data.sharpeRatio},
+                         {"max_drawdown", data.maxDrawdown},
+                         {"win_rate", data.winRate},
+                         {"total_trades", data.totalTrades},
+                         {"ml_accuracy", data.mlAccuracy},
+                         {"prediction_time", data.avgPredictionTime}});
+    }
+    performance = std::move(history);
+  } else {
+    auto data = m_collector->getLatestPerformance(strategyId);
+    performance = {{"pnl", data.pnl},
+                   {"position", data.position},
+                   {"sharpe_ratio", data.sharpeRatio},
+                   {"max_drawdown", data.maxDrawdown},
+                   {"win_rate", data.winRate},
+                   {"total_trades", data.totalTrades},
+                   {"ml_accuracy", data.mlAccuracy},
+                   {"prediction_time", data.avgPredictionTime}};
+  }
 
   auto response = createSuccessResponse(performance);
 
@@ -1337,6 +1423,13 @@ void VisualizationServer::updateMarketData(const std::string& symbol,
                                            const MarketData& data) {
   if (m_collector) {
     m_collector->updateMarketData(symbol, data);
+  }
+}
+
+void VisualizationServer::recordPerformance(const std::string& strategyId,
+                                            const PerformanceData& data) {
+  if (m_collector) {
+    m_collector->recordPerformance(strategyId, data);
   }
 }
 

--- a/visualization/WebServer.cpp
+++ b/visualization/WebServer.cpp
@@ -1097,11 +1097,6 @@ parseQueryString(const std::string& query) {
   return params;
 }
 
-std::string RestAPIServer::urlDecode(const std::string& str) {
-  std::string decoded;
-  return decodeQueryComponent(str, decoded) ? decoded : std::string{};
-}
-
 std::string RestAPIServer::extractPath(const std::string& target) {
   auto pos = target.find('?');
   return pos != std::string::npos ? target.substr(0, pos) : target;

--- a/visualization/WebServer.h
+++ b/visualization/WebServer.h
@@ -11,6 +11,7 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/websocket.hpp>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -91,10 +92,15 @@ public:
   void registerStrategy(const std::string& strategyId,
                         std::shared_ptr<void> strategy);
   void unregisterStrategy(const std::string& strategyId);
+  void recordPerformance(const std::string& strategyId,
+                         const PerformanceData& data);
   void startCollection(uint64_t intervalMs = 1000);
   void stopCollection();
 
   PerformanceData getLatestPerformance(const std::string& strategyId) const;
+  std::vector<PerformanceData>
+  getPerformanceHistory(const std::string& strategyId, uint64_t startTime,
+                        uint64_t endTime) const;
   std::vector<ChartDataPoint> getChartData(const std::string& strategyId,
                                            const std::string& metric,
                                            uint64_t timeRange) const;
@@ -108,6 +114,8 @@ private:
   std::atomic<bool> m_collecting{false};
   std::thread m_collectionThread;
   size_t m_maxHistorySize{10000};
+  std::unordered_map<std::string, std::deque<PerformanceData>>
+      m_performanceHistory;
   std::unordered_map<std::string, MarketData> m_marketData;
 };
 
@@ -312,6 +320,8 @@ public:
 
   // Market data updates
   void updateMarketData(const std::string& symbol, const MarketData& data);
+  void recordPerformance(const std::string& strategyId,
+                         const PerformanceData& data);
 
   // Backtest integration
   void addBacktestResults(const std::string& backtestId,


### PR DESCRIPTION
# Pull Request

## Description
Implement REST performance time-range filtering and query-driven chart filtering.

This PR builds on the merged REST query-string parsing work. It applies parsed query parameters to the performance and chart endpoints, adds bounded historical data storage, records live performance samples, and documents the resulting API behavior.

Example performance request:

```http
GET /api/v1/strategies/primary_strategy/performance?start=100&end=300&limit=50
```

returns matching performance snapshots within the inclusive range.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] Refactoring (no functional changes)

## Areas Changed
- [ ] Core Engine (order book, execution)
- [ ] Trading Strategies
- [ ] Exchange Connectivity
- [ ] Security Infrastructure
- [ ] Performance/Benchmarks
- [x] Documentation
- [ ] CI/CD
- [x] Visualization / REST API
- [x] Tests

## Testing
- [x] Unit tests pass locally
- [x] Performance benchmarks run successfully
- [x] Manual testing completed
- [x] Security validation performed (if applicable)

Validation completed:
```
WebServerTests: passed
CTest: 100% tests passed
C++ pre-commit hooks: passed
```

Added tests for:

* Inclusive performance time-range filtering
* Performance result limits
* Maximum history-size enforcement
* Chart timestamp-range filtering
* Query-bearing chart route extraction
* Invalid and reversed performance ranges
* Invalid performance limits
* Empty performance ranges
* Latest snapshot object response shape
* Historical array response shape
* Strategy history cleanup after `unregisterStrategy()`

## Performance Impact
- [ ] No performance impact
- [ ] Performance improvement (include benchmark results)
- [x] Potential performance regression (justify and include mitigation)

Performance history is bounded by `maxHistorySize`, which prevents unbounded memory growth. 

Performance range queries can also stop after reaching the requested `limit`.

## Security Considerations
- [x] No security implications
- [ ] Security enhancement
- [ ] Requires security review

Timestamp values are parsed with `std::from_chars`, and malformed or reversed ranges return HTTP `400 Bad Request`. Unknown query parameters are ignored.

## API Behavior

Performance Endpoint

```GET /api/v1/strategies/{strategy_id}/performance```

Supported parameters:

```
start=<timestamp>
end=<timestamp>
limit=<number>
```

Example:

```GET /api/v1/strategies/primary_strategy/performance?start=100&end=300&limit=2```

Requests without `start`, `end`, or `limit` preserve the existing response format and return the latest performance snapshot as an object.

Requests with any of these parameters return an array of matching historical snapshots.

`start` and `end` bounds are inclusive.

Chart Endpoint
```GET /api/v1/strategies/{strategy_id}/charts/{metric}```

Supported parameters:

```
range=<duration>
start=<timestamp>
end=<timestamp>
```

Supported range units include:
```
s  seconds
m  minutes
h  hours
d  days
```

Examples:
```GET /api/v1/strategies/primary_strategy/charts/pnl?range=1h```
```GET /api/v1/strategies/primary_strategy/charts/pnl?start=100&end=300```

Explicit start and end values take precedence over range.

Invalid or reversed chart ranges return HTTP 400 Bad Request.

## Data Collection
The following APIs are available for populating retained data:

```cpp
PerformanceCollector::recordPerformance(...)
PerformanceCollector::recordChartData(...)
VisualizationServer::recordPerformance(...)
VisualizationServer::recordChartData(...)
```

When visualization is enabled, the main application loop records live performance snapshots containing the timestamp, PnL, and position.

Chart history remains empty until chart-data producers call `recordChartData()`.

## Documentation
Updated:
* README.md
* docs/STRATEGY_PERFORMANCE_VISUALIZATION.md

The documentation describes supported query parameters, response shapes, range validation, and bounded history behavior.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation made
- [x] Tests added that prove the fix is effective or that the feature works
- [x] Any dependent changes have been merged and published

The dependent query-parsing changes have been published in the base branch. The base PR should be merged before this PR is retargeted to `main`.

## Related Issues
* Closes #75
* Chart-data functionality is also related to #84.

## Screenshots/Benchmark Results
Not applicable

## Additional Notes
The implementation is organized into focused commits:

* `feat: support REST performance result limits`
* `feat: route REST strategy chart requests`
* `feat: support REST chart time ranges`
* `test: cover REST performance query handling`
* `feat: record live performance history`
* `docs: document REST query filters`

Existing behavior is preserved for requests without supported query parameters.


